### PR TITLE
[docs] fix typo in Perl6::Perl5::Differences

### DIFF
--- a/docs/Perl6/Perl5/Differences.pod
+++ b/docs/Perl6/Perl5/Differences.pod
@@ -202,7 +202,7 @@ parentheses for either indexing or method calls:
     $s();
     # or
     $s.();
-    $lol.[1][0]
+    $aoa.[1][0]
 
 =cut
 


### PR DESCRIPTION
In a previous commit (6c70e440) a variable name was changed from $lol to $aoa to more
accurately describe what was going on, but one instance of $lol remained
a bit further down in the text.

I noticed this because http://design.perl6.org/Differences.html was linked from Hacker News.